### PR TITLE
Optimization: Execute Individual Sites in Parallel

### DIFF
--- a/api/algorithm_instance.py
+++ b/api/algorithm_instance.py
@@ -1,5 +1,6 @@
-from collections import OrderedDict
-from typing import IO, List, Union
+from collections import OrderedDict, namedtuple
+import multiprocessing
+from typing import IO, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -7,6 +8,9 @@ import pandas as pd
 from api.algorithm_site_instance import AlgorithmSiteInstance, SavedState
 from api.data_file_parser import DataFileParser
 from api.recrudescence_file_parser import RecrudescenceFileParser
+
+
+RunInputArgs = namedtuple('RunInputArgs', 'nruns burnin record_interval seed')
 
 
 class AlgorithmResults:
@@ -180,14 +184,36 @@ class AlgorithmInstance:
         '''
         overall_results = AlgorithmResults()
 
-        for site_name, algo_instance in self.algorithm_instances:
-            site_result = algo_instance.run_algorithm(
-                site_name,
-                nruns,
-                burnin,
-                record_interval,
-                seed)
-            # save site results
-            overall_results.update_results(site_result, site_name)
+        num_sites = len(self.algorithm_instances)
+        with multiprocessing.Pool(processes=num_sites) as pool:
+            run_inputs = [RunInputArgs(nruns, burnin, record_interval, seed)] * num_sites
+            all_site_arguments = zip(self.algorithm_instances, run_inputs)
+            site_results = pool.starmap(
+                self._run_site_algorithm,
+                all_site_arguments)
+
+            for site_name, site_result in site_results:
+                # save site results
+                overall_results.update_results(site_result, site_name)
 
         return overall_results
+
+    @classmethod
+    def _run_site_algorithm(cls,
+        site_instance: Tuple[str, AlgorithmSiteInstance],
+        run_inputs: RunInputArgs) -> Tuple[str, SavedState]:
+        '''
+        Runs the algorithm for a single site instance, and returns the
+        algorithm results along with the site name
+        :param site_instance: The site to start running the algorithm for
+        :run_inputs: The input arguments to the algorithm run
+        :return: A tuple containing the site name and site algorithm results
+        '''
+        site_name, algo_instance = site_instance
+        site_result = algo_instance.run_algorithm(
+            site_name,
+            run_inputs.nruns,
+            run_inputs.burnin,
+            run_inputs.record_interval,
+            run_inputs.seed)
+        return site_name, site_result

--- a/main.py
+++ b/main.py
@@ -4,24 +4,24 @@ import numpy as np
 
 from api.algorithm_instance import AlgorithmInstance, AlgorithmResults
 
+if __name__ == '__main__':
+    # user inputs
+    inputfile = "Angola2017_example.xlsx"
+    locirepeats = np.array([2,2,3,3,3,3,3])
+    nruns = 1000
 
-# user inputs
-inputfile = "Angola2017_example.xlsx"
-locirepeats = np.array([2,2,3,3,3,3,3])
-nruns = 10
+    # Import/set up data
+    test_run = AlgorithmInstance(inputfile, locirepeats)
 
-# Import/set up data
-test_run = AlgorithmInstance(inputfile, locirepeats)
+    # calculate burnin (number of runs to discard) and record interval (which n_th iterations should be recorded)
+    record_interval = np.ceil(nruns / 1000)
+    burnin = np.ceil(nruns * 0.25)
 
-# calculate burnin (number of runs to discard) and record interval (which n_th iterations should be recorded)
-record_interval = np.ceil(nruns / 1000)
-burnin = np.ceil(nruns * 0.25)
+    results = test_run.run_algorithm(nruns, burnin, record_interval)
 
-results = test_run.run_algorithm(nruns, burnin, record_interval)
-
-# Output summary data to .csv files
-file_content = results.get_output_file_text()
-for filename, text in file_content.items():
-    csv_file = open(filename, 'w')
-    csv_file.write(text)
-    csv_file.close()
+    # Output summary data to .csv files
+    file_content = results.get_output_file_text()
+    for filename, text in file_content.items():
+        csv_file = open(filename, 'w')
+        csv_file.write(text)
+        csv_file.close()


### PR DESCRIPTION
Since the individual site algorithms are completely independent of each other, I made a slight change to run each site's computations in its own thread and then aggregate the results. On the example file, this leads to a 40% increase in performance (52s vs 72.5s average at N=1000); however, mileage will vary depending on how many sites there are.

### Performance discussion
In general, this will make files with multiple sites run significantly faster, but slightly slows down runs with just 1 site (since there's some overhead to starting a new thread). See the graph below (blue is the new multithreaded code, red is the current `master` branch):

![multiPerformanceGraph](https://user-images.githubusercontent.com/22411098/98743954-e2a13800-237e-11eb-8caa-8a705f79b7dc.PNG)

With 0 iterations, the serial code takes 1.41s and the multithreaded code 2.71s - a slight downgrade for low iteration counts or ~+1 second if there's only 1 site. Past ~50 iterations, though (well below what most researchers use), the example file runs significantly faster (theoretically approaching a 45% improvement as nruns goes to infinity *for this specific file*).

Since the 3rd site is a bottleneck in our example file (taking significantly longer), the gains aren't as significant as they could be. In a file with 5 sites each taking the same amount of time, this code would give nearly a 500% speed improvement.